### PR TITLE
fix: video acceleration under Wayland

### DIFF
--- a/0006-i965_device_info.c-Add-missing-entries-to-gen7_cpu_h.patch
+++ b/0006-i965_device_info.c-Add-missing-entries-to-gen7_cpu_h.patch
@@ -1,0 +1,58 @@
+From ab755cb7c4079a0884ede18b232341fe36affb8c Mon Sep 17 00:00:00 2001
+From: Patrick Thompson <ptf@google.com>
+Date: Wed, 12 Oct 2022 17:00:14 -0400
+Subject: [PATCH 06/10] i965_device_info.c: Add missing entries to
+ gen7_cpu_hook_list
+
+Based on https://ark.intel.com/content/www/us/en/ark/products/graphics/96744/intel-hd-graphics-for-3rd-generation-intel-processors.html#@nofilter these processors do not support h264 hardware encoding and should be added to the gen7_cpu_hook_list.
+
+Signed-off-by: Patrick Thompson ptf@google.com
+---
+ src/i965_device_info.c | 28 ++++++++++++++++++++++++++++
+ 1 file changed, 28 insertions(+)
+
+diff --git a/src/i965_device_info.c b/src/i965_device_info.c
+index a6adcf5..6c7bfd9 100644
+--- a/src/i965_device_info.c
++++ b/src/i965_device_info.c
+@@ -1065,9 +1065,37 @@ static void gen6_hw_codec_preinit(VADriverContextP ctx, struct hw_codec_info *co
+  * It is captured by /proc/cpuinfo and the space character is stripped.
+  */
+ const static char *gen7_cpu_hook_list[] =  {
++    "Intel(R)Celeron(R)CPUG1620T",
++    "Intel(R)Celeron(R)CPUG1630",
++    "Intel(R)Celeron(R)CPU1005M",
++    "Intel(R)Celeron(R)CPU1017U",
++    "Intel(R)Celeron(R)CPU1019Y",
++    "Intel(R)Celeron(R)CPU1000M",
+     "Intel(R)Celeron(R)CPU1007U",
++    "Intel(R)Celeron(R)CPU1020E",
++    "Intel(R)Celeron(R)CPU1020M",
+     "Intel(R)Celeron(R)CPU1037U",
++    "Intel(R)Celeron(R)CPU1047UE",
++    "Intel(R)Celeron(R)CPU927UE",
++    "Intel(R)Celeron(R)CPUG1610",
++    "Intel(R)Celeron(R)CPUG1610T",
++    "Intel(R)Celeron(R)CPUG1620",
++    "Intel(R)Pentium(R)CPU2020M",
++    "Intel(R)Pentium(R)CPU2030M",
++    "Intel(R)Pentium(R)CPU2117U",
++    "Intel(R)Pentium(R)CPU2127U",
++    "Intel(R)Pentium(R)CPU2129Y",
++    "Intel(R)Pentium(R)CPUA1018",
++    "Intel(R)Pentium(R)CPUG2010",
++    "Intel(R)Pentium(R)CPUG2020",
++    "Intel(R)Pentium(R)CPUG2020T",
++    "Intel(R)Pentium(R)CPUG2030",
++    "Intel(R)Pentium(R)CPUG2030T",
++    "Intel(R)Pentium(R)CPUG2100T",
++    "Intel(R)Pentium(R)CPUG2120",
++    "Intel(R)Pentium(R)CPUG2120T",
+     "Intel(R)Pentium(R)CPUG2130",
++    "Intel(R)Pentium(R)CPUG2140",
+ };
+ 
+ static void gen7_hw_codec_preinit(VADriverContextP ctx, struct hw_codec_info *codec_info)
+-- 
+2.47.1.windows.1
+

--- a/0007-Update-COPYING-with-copyright-line.patch
+++ b/0007-Update-COPYING-with-copyright-line.patch
@@ -1,0 +1,27 @@
+From 670090027d6cb61f95ef88fc35bc309117a04a94 Mon Sep 17 00:00:00 2001
+From: jchinlee <jchinlee94@gmail.com>
+Date: Mon, 10 Jul 2023 15:39:02 -0700
+Subject: [PATCH 07/10] Update COPYING with copyright line
+
+The MIT license requires a copyright line specifying the year of application and copyright holder. [0]
+
+Add this line to the existing COPYING file containing the rest of the license text.
+
+[0] https://opensource.org/license/mit/
+---
+ COPYING | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/COPYING b/COPYING
+index 900e775..6270fa9 100644
+--- a/COPYING
++++ b/COPYING
+@@ -1,3 +1,5 @@
++    Copyright (c) 2023 Intel Corporation
++
+     Permission is hereby granted, free of charge, to any person obtaining a
+     copy of this software and associated documentation files (the
+     "Software"), to deal in the Software without restriction, including
+-- 
+2.47.1.windows.1
+

--- a/0008-add-required-SECURITY.md-file-for-OSSF-Scorecard-com.patch
+++ b/0008-add-required-SECURITY.md-file-for-OSSF-Scorecard-com.patch
@@ -1,0 +1,25 @@
+From 06c9a893581c975c365c2281a1e597197b558085 Mon Sep 17 00:00:00 2001
+From: Robert Dower <robert.dower@intel.com>
+Date: Fri, 3 May 2024 14:57:31 -0700
+Subject: [PATCH 08/10] add required SECURITY.md file for OSSF Scorecard
+ compliance
+
+---
+ SECURITY.md | 5 +++++
+ 1 file changed, 5 insertions(+)
+ create mode 100644 SECURITY.md
+
+diff --git a/SECURITY.md b/SECURITY.md
+new file mode 100644
+index 0000000..373608b
+--- /dev/null
++++ b/SECURITY.md
+@@ -0,0 +1,5 @@
++# Security Policy
++Intel is committed to rapidly addressing security vulnerabilities affecting our customers and providing clear guidance on the solution, impact, severity and mitigation.
++
++## Reporting a Vulnerability
++Please report any security vulnerabilities in this project utilizing the guidelines [here](https://www.intel.com/content/www/us/en/security-center/vulnerability-handling-guidelines.html).
+-- 
+2.47.1.windows.1
+

--- a/0009-Make-wl_drm-optional.patch
+++ b/0009-Make-wl_drm-optional.patch
@@ -1,0 +1,49 @@
+From d30e01329344858f3c84d0ef9c2b68cbde37bb9a Mon Sep 17 00:00:00 2001
+From: Simon Ser <contact@emersion.fr>
+Date: Mon, 11 Mar 2024 23:48:17 +0100
+Subject: [PATCH 09/10] Make wl_drm optional
+
+Don't error out when vtable->wl_interface is NULL.
+
+Fetching wl_drm_interface from libEGL used to work but doesn't
+anymore: it's now a private symbol (wayland-scanner private-code).
+---
+ src/i965_output_wayland.c | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/src/i965_output_wayland.c b/src/i965_output_wayland.c
+index a6120b7..a002cae 100644
+--- a/src/i965_output_wayland.c
++++ b/src/i965_output_wayland.c
+@@ -154,7 +154,7 @@ registry_handle_global(
+     struct va_wl_output * const wl_output = i965->wl_output;
+     struct wl_vtable * const wl_vtable = &wl_output->vtable;
+ 
+-    if (strcmp(interface, "wl_drm") == 0) {
++    if (strcmp(interface, "wl_drm") == 0 && wl_vtable->drm_interface) {
+         wl_output->wl_drm_name = name;
+         wl_output->wl_drm = registry_bind(wl_vtable, wl_output->wl_registry,
+                                           name, wl_vtable->drm_interface,
+@@ -472,6 +472,7 @@ i965_output_wayland_init(VADriverContextP ctx)
+ 
+     wl_vtable = &i965->wl_output->vtable;
+ 
++    /* drm_interface is optional */
+     if (vtable->wl_interface)
+         wl_vtable->drm_interface = vtable->wl_interface;
+     else {
+@@ -483,9 +484,8 @@ i965_output_wayland_init(VADriverContextP ctx)
+         }
+ 
+         dso_handle = i965->wl_output->libegl_handle;
+-        if (!dso_get_symbols(dso_handle, wl_vtable, sizeof(*wl_vtable),
+-                             libegl_symbols))
+-            goto error;
++        dso_get_symbols(dso_handle, wl_vtable, sizeof(*wl_vtable),
++                        libegl_symbols);
+     }
+ 
+     i965->wl_output->libwl_client_handle = dso_open(LIBWAYLAND_CLIENT_NAME);
+-- 
+2.47.1.windows.1
+

--- a/intel-vaapi-driver.spec
+++ b/intel-vaapi-driver.spec
@@ -16,6 +16,10 @@ Patch1:     0002-Handle-odd-resolution.patch
 Patch2:     0003-Avoid-GPU-crash-with-malformed-streams.patch
 Patch3:     0004-The-3D-multisample-state-needs-to-be-resent-as-part-.patch
 Patch4:     0005-Fix-VP9.2-config-verification.patch
+Patch5:     0006-i965_device_info.c-Add-missing-entries-to-gen7_cpu_h.patch
+Patch6:     0007-Update-COPYING-with-copyright-line.patch
+Patch7:     0008-add-required-SECURITY.md-file-for-OSSF-Scorecard-com.patch
+Patch8:     0009-Make-wl_drm-optional.patch
 
 ExclusiveArch:  %{ix86} x86_64
 


### PR DESCRIPTION
VAAPI got broken with libva 2.22, see https://github.com/intel/intel-vaapi-driver/pull/566

It looks like no new release will be prepared as the project is now discontinued, see https://github.com/intel/intel-vaapi-driver/pull/569.